### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/kohzuApp/src/drvSC800.cc
+++ b/kohzuApp/src/drvSC800.cc
@@ -94,7 +94,7 @@ volatile double drvSC800ReadbackDelay = 0.;
 
 /*----------------functions-----------------*/
 static int recv_mess(int card, char *com, int flag);
-static RTN_STATUS send_mess(int card, char const *, char *name);
+static RTN_STATUS send_mess(int card, const char *, const char *name);
 static int set_status(int card, int signal);
 static long report(int level);
 static long init();
@@ -221,7 +221,7 @@ static int set_status(int card, int signal)
 	charcnt = recv_mess(card, buff, FLUSH);
 
     sprintf(buff,"STR1/%d",(signal + 1));
-    send_mess(card, buff, (char*) NULL);		/*  Tell Status */
+    send_mess(card, buff, NULL);		/*  Tell Status */
     charcnt = recv_mess(card, buff, 1);
     convert_cnt = sscanf(buff, "C\tSTR%d\t1\t%d\t%d\t%d\t%d\t%d\t%d\t%d",
                          &str_axis, &str_move, &str_norg, &str_orgg,
@@ -256,7 +256,7 @@ static int set_status(int card, int signal)
 
    /* Parse motor position */
     sprintf(buff,"RDP%d/0", (signal + 1));
-    send_mess(card, buff, (char*) NULL);  /*  Tell Position */
+    send_mess(card, buff, NULL);  /*  Tell Position */
     recv_mess(card, buff, 1);
     convert_cnt = sscanf(buff, "C\tRDP%d\t%d", &str_axis, &motorData);
     
@@ -285,7 +285,7 @@ static int set_status(int card, int signal)
 
     /* Torque enabled? */
     sprintf(buff,"RSY%d/21", (signal + 1));
-    send_mess(card, buff, (char*) NULL);  /*  Tell Position */
+    send_mess(card, buff, NULL);  /*  Tell Position */
     recv_mess(card, buff, 1);
     convert_cnt = sscanf(buff, "C\tRSY%d\t21\t%d", &str_axis, &str_move);
     status.Bits.EA_POSITION = (str_move == 0) ? 1 : 0;
@@ -327,7 +327,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -341,7 +341,7 @@ exit:
 /* send a message to the SC800 board                 */
 /* send_mess()                                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct SC800Controller *cntrl;
     char local_buff[MAX_MSG_SIZE];


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.